### PR TITLE
Feat/atom with storage new type

### DIFF
--- a/src/core/atom.ts
+++ b/src/core/atom.ts
@@ -74,7 +74,9 @@ export interface WritableAtom<
   onMount?: OnMount<Update, Result>
 }
 
-type SetStateAction<Value> = Value | ((prev: Value) => Value)
+export type SetStateActionFunc<Value> = (prev: Value) => Value
+
+type SetStateAction<Value> = Value | SetStateActionFunc<Value>
 
 export type PrimitiveAtom<Value> = WritableAtom<Value, SetStateAction<Value>>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,12 @@ export { useAtom } from './core/useAtom'
 export { useAtomValue } from './core/useAtomValue'
 export { useSetAtom } from './core/useSetAtom'
 export { createStoreForExport as unstable_createStore } from './core/store'
-export type { Atom, WritableAtom, PrimitiveAtom } from './core/atom'
+export type {
+  Atom,
+  WritableAtom,
+  PrimitiveAtom,
+  SetStateActionFunc,
+} from './core/atom'
 export type {
   Getter,
   Setter,

--- a/src/utils/atomWithDefault.ts
+++ b/src/utils/atomWithDefault.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai'
 import type { Atom, SetStateAction, WritableAtom } from 'jotai'
+import { SetStateActionFunc } from 'jotai/core/atom'
 import { RESET } from './constants'
 
 type Read<Value> = Atom<Value>['read']
@@ -35,7 +36,7 @@ export function atomWithDefault<Value>(getDefault: Read<Value>) {
         return set(
           overwrittenAtom,
           typeof update === 'function'
-            ? (update as (prev: Value) => Value)(get(anAtom))
+            ? (update as SetStateActionFunc<Value>)(get(anAtom))
             : update
         )
       }

--- a/src/utils/atomWithDefault.ts
+++ b/src/utils/atomWithDefault.ts
@@ -1,6 +1,10 @@
 import { atom } from 'jotai'
-import type { Atom, SetStateAction, WritableAtom } from 'jotai'
-import { SetStateActionFunc } from 'jotai/core/atom'
+import type {
+  Atom,
+  SetStateAction,
+  SetStateActionFunc,
+  WritableAtom,
+} from 'jotai'
 import { RESET } from './constants'
 
 type Read<Value> = Atom<Value>['read']

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,5 +1,6 @@
 import { atom } from 'jotai'
 import type { SetStateAction, WritableAtom } from 'jotai'
+import { SetStateActionFunc } from 'jotai/core/atom'
 import { RESET } from './constants'
 
 export function atomWithReset<Value>(initialValue: Value) {
@@ -11,7 +12,7 @@ export function atomWithReset<Value>(initialValue: Value) {
       set(
         anAtom,
         typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(anAtom))
+          ? (update as SetStateActionFunc<Value>)(get(anAtom))
           : update
       )
     }

--- a/src/utils/atomWithReset.ts
+++ b/src/utils/atomWithReset.ts
@@ -1,6 +1,5 @@
 import { atom } from 'jotai'
-import type { SetStateAction, WritableAtom } from 'jotai'
-import { SetStateActionFunc } from 'jotai/core/atom'
+import type { SetStateAction, SetStateActionFunc, WritableAtom } from 'jotai'
 import { RESET } from './constants'
 
 export function atomWithReset<Value>(initialValue: Value) {

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -9,13 +9,9 @@ type ReplaceReturnType<T extends (...a: any) => any, TNewReturn> = (
   ...a: Parameters<T>
 ) => TNewReturn
 
-type ResetFuncReturnType<Value> =
-  | ReturnType<SetStateActionFunc<Value>>
-  | typeof RESET
-
 type ResetSetStateActionFunc<Value> = ReplaceReturnType<
   SetStateActionFunc<Value>,
-  ResetFuncReturnType<Value>
+  ReturnType<SetStateActionFunc<Value>> | typeof RESET
 >
 
 type StorageSetStateAction<Value> =

--- a/src/utils/atomWithStorage.ts
+++ b/src/utils/atomWithStorage.ts
@@ -1,6 +1,5 @@
-import { SetStateAction, atom } from 'jotai'
-import type { WritableAtom } from 'jotai'
-import { SetStateActionFunc } from 'jotai/core/atom'
+import { atom } from 'jotai'
+import type { SetStateAction, SetStateActionFunc, WritableAtom } from 'jotai'
 import { RESET } from './constants'
 
 type Unsubscribe = () => void

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -1,6 +1,7 @@
 import { snapshot, subscribe } from 'valtio/vanilla'
 import { atom } from 'jotai'
 import type { SetStateAction } from 'jotai'
+import { SetStateActionFunc } from 'jotai/core/atom'
 
 const isObject = (x: unknown): x is object =>
   typeof x === 'object' && x !== null
@@ -61,7 +62,7 @@ export function atomWithProxy<Value extends object>(
     (get, _set, update: SetStateAction<Value>) => {
       const newValue =
         typeof update === 'function'
-          ? (update as (prev: Value) => Value)(get(baseAtom) as Value)
+          ? (update as SetStateActionFunc<Value>)(get(baseAtom) as Value)
           : update
       applyChanges(proxyObject, snapshot(proxyObject) as Value, newValue)
     }

--- a/src/valtio/atomWithProxy.ts
+++ b/src/valtio/atomWithProxy.ts
@@ -1,7 +1,6 @@
 import { snapshot, subscribe } from 'valtio/vanilla'
 import { atom } from 'jotai'
-import type { SetStateAction } from 'jotai'
-import { SetStateActionFunc } from 'jotai/core/atom'
+import type { SetStateAction, SetStateActionFunc } from 'jotai'
 
 const isObject = (x: unknown): x is object =>
   typeof x === 'object' && x !== null


### PR DESCRIPTION
- Create new `SetStateActionFunc` which represent signature for all `SetStateAction` callbacks
- Add new type `ResetSetStateActionFunc` which replaces return type of `SetStateActionFunc` with a union of `ReturnType<SetStateActionFunc<Value>> | typeof RESET`
- Create new `StorageSetStateAction` which is union of `SetStateAction<Value>  | ResetSetStateActionFunc<Value>`